### PR TITLE
MPDP-685 Update start script

### DIFF
--- a/start
+++ b/start
@@ -36,13 +36,6 @@ cd "${projectRoot}"
 cd ./fcp-mpdp-frontend && \
   docker compose up -d
 
-echo "Waiting for fcp-mpdp-frontend-localstack to become healthy..."
-until docker compose ps localstack | grep "healthy" >/dev/null; do
-  echo "fcp-mpdp-frontend-localstack not healthy yet, waiting 3 seconds..."
-  sleep 
-done
-echo "fcp-mpdp-frontend-localstack is healthy."
-
 if [ "$run_journey_tests" = true ]; then
   echo "Starting fcp-mpdp-journey-test-suite..."
   cd "${projectRoot}"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/MPDP-685
Updating the `start` script to remove the wait interval. This was initially added to ensure the `fcp-mpdp-frontend-localstack` container was up and running in order to create the S3 bucket where perf test reports would be saved. The perf test suite (`fcp-mpdp-performance-test-suite`) has since been updated to use its own localstack container for creating the S3 bucket to store the reports instead so there is no longer a dependency on waiting for the frontend localstack container to have started/be healthy.
