### PR TITLE
Increase number of fake database entries

### DIFF
--- a/data/seed.js
+++ b/data/seed.js
@@ -8,7 +8,7 @@ async function seed() {
   try {
     await dbClient.query(`TRUNCATE payment_activity_data, aggregate_scheme_payments RESTART IDENTITY;`)
 
-    for (let i = 0; i < 100; i++) {
+    for (let i = 0; i < 5000; i++) {
       const record = generateFakePaymentActivityData()
       await dbClient.query(
         `INSERT INTO payment_activity_data


### PR DESCRIPTION
Small PR to increase the number of fake entries inserted into the database from 100 to 5000. This is so that locally the number of records is more like the real database (albeit still significantly less entries).
