### PR TITLE
Add known database record for journey tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,35 +23,29 @@ There are several diagrams illustrating the architecture for MPDP that are avail
 
 ## Scripts
 
-### Help
+### [Help](./help)
 
 List all available commands.  
-[`./help`](./help)
 
-### Clone
+### [Clone](./clone)
 
 Clone all repositories from GitHub. Repositories will be cloned in the parent directory of this repository.  
-[`./clone`](./clone)
 
-### Update
+### [Update](./update)
 
 Switch to main branch in every repository and pull latest changes with `git pull`.  
-[`./update`](./update)
 
-### Pull
+### [Pull](./pull)
 
 Pull latest changes from current branch in every repository with `git pull`.  
-[`./pull`](./pull)
 
-### Build
+### [Build](./build)
 
 Build/rebuild Docker container for all microservices.  
-[`./build`](./build)
 
-### Start
+### [Start](./start)
 
 Run all services in detached mode.  
-[`./start`](./start)
 
 #### Optional arguments 
 
@@ -62,29 +56,26 @@ Any valid `docker compose down` argument.
 `-pt` or `--performance-tests` to run the performance test suite.  
 Any combination of the above options.
 
-### Seed
+### [Seed](./seed)
 
 Utilises [fakerjs](https://fakerjs.dev) to generate fake data to populate the backend PostgreSQL database for local development. There is no need to interact with this script directly as it can be executed as an optional argument via the [`start`](#start) script.  
-[`./seed`](./seed)
+To ensure the journey test suite passes both locally and during CI/CD on CDP, a `testData` object is used to insert a known record (i.e. one which already exists in all CDP databases excluding production). This object can be easily updated at any time to match any existing record in the CDP databases. If the `testData` object is updated, ensure to make the same changes to the `testData` object on [fcp-mpdp-journey-test-suite](https://github.com/DEFRA/fcp-mpdp-journey-test-suite/blob/main/utils/test-data.js).  
 
-### Stop
+### [Stop](./stop)
 
 Stop all services.  
-[`./stop`](./stop)
 
 #### Optional arguments
 
 Any valid `docker compose down` argument.
 
-### Open
+### [Open](./open)
 
 Open all microservices in Visual Studio Code.  
-[`./open`](./open)
 
-### Version
+### [Version](./version)
 
 List latest GitHub release/tag version for each microservice.  
-[`./version`](./version)
 
 ## VS Code Command Palette
 

--- a/data/seed.js
+++ b/data/seed.js
@@ -8,7 +8,7 @@ async function seed() {
   try {
     await dbClient.query(`TRUNCATE payment_activity_data, aggregate_scheme_payments RESTART IDENTITY;`)
 
-    for (let i = 0; i < 100; i++) {
+    for (let i = 0; i < 5000; i++) {
       const record = generateFakePaymentActivityData()
       await dbClient.query(
         `INSERT INTO payment_activity_data

--- a/data/seed.js
+++ b/data/seed.js
@@ -8,6 +8,26 @@ async function seed() {
   try {
     await dbClient.query(`TRUNCATE payment_activity_data, aggregate_scheme_payments RESTART IDENTITY;`)
 
+    // Insert known record so journey tests are consistent locally and in CDP's test environment
+    await dbClient.query(
+      `INSERT INTO payment_activity_data
+      (payee_name, part_postcode, town, parliamentary_constituency, county_council, scheme, amount, financial_year, payment_date, scheme_detail, activity_level)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+      [
+        'Feeney and Sons',
+        'GO15',
+        'Alekfield',
+        'Funkfield',
+        'Cleveland',
+        'Farming Resilience Fund',
+        33577.90,
+        '23/24',
+        '2024-04-22',
+        'Staff cost',
+        ''
+      ]
+    )
+
     for (let i = 0; i < 5000; i++) {
       const record = generateFakePaymentActivityData()
       await dbClient.query(

--- a/data/seed.js
+++ b/data/seed.js
@@ -1,5 +1,6 @@
 import { dbClient } from './db-client.js'
 import { generateFakePaymentActivityData, generateFakeAggregateSchemePaymentsData } from './generate-data.js'
+import { testData } from './test-data.js'
 import { yearlyTotalSchemes } from './constants.js'
 
 async function seed() {
@@ -14,17 +15,17 @@ async function seed() {
       (payee_name, part_postcode, town, parliamentary_constituency, county_council, scheme, amount, financial_year, payment_date, scheme_detail, activity_level)
       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
       [
-        'Feeney and Sons',
-        'GO15',
-        'Alekfield',
-        'Funkfield',
-        'Cleveland',
-        'Farming Resilience Fund',
-        33577.90,
-        '23/24',
-        '2024-04-22',
-        'Staff cost',
-        ''
+        testData.payeeName,
+        testData.partPostcode,
+        testData.town,
+        testData.parliamentaryConstituency,
+        testData.countyCouncil,
+        testData.scheme,
+        testData.amount,
+        testData.financialYear,
+        testData.paymentDate,
+        testData.schemeDetail,
+        testData.activityLevel
       ]
     )
 

--- a/data/test-data.js
+++ b/data/test-data.js
@@ -1,0 +1,17 @@
+/** Change the values below to match any existing record in the DEV, TEST, or PERF-TEST databases on CDP.
+ * This will ensure that journey tests pass both locally and during the CI/CD pipelines on CDP.
+ */
+
+export const testData = {
+  payeeName: 'Feeney and Sons',
+  partPostcode: 'GO15',
+  town: 'Alekfield',
+  parliamentaryConstituency: 'Funkfield',
+  countyCouncil: 'Cleveland',
+  scheme: 'Farming Resilience Fund',
+  amount: 33577.90,
+  financialYear: '23/24',
+  paymentDate: '2024-04-02',
+  schemeDetail: 'Staff cost',
+  activityLevel: ''
+}


### PR DESCRIPTION
Updating the seed function to insert a known database record that's also present in the database in CDP's test environment which we set up previously so that journey tests are possible against the /details route and will pass locally and via CI/CD pipelines.
