### PR TITLE
Update schemes in seed script data

### DIFF
--- a/data/constants.js
+++ b/data/constants.js
@@ -1,7 +1,6 @@
 export const schemes = [
   'Farming Resilience Fund',
   'Landscape Recovery',
-  'New Entrants Pilot',
   'Sustainable Farming Incentive',
   'Countryside Stewardship',
   'Farming Investment Fund'


### PR DESCRIPTION
Small PR to update the names of schemes used in the seed script to better align with what the real service lists by removing `New Entrants Pilot`.
